### PR TITLE
Add MoonScript (.moon) file support to models.py

### DIFF
--- a/solution/models.py
+++ b/solution/models.py
@@ -19,6 +19,7 @@ languages = {
     '.lhs' : 'Haskell',
     '.lol' : 'LOLCODE',
     '.lols' : 'LOLCODE',
+    '.moon' : 'MoonScript',
     '.php' : 'PHP',
     '.py' : 'Python',
     '.rb' : 'Ruby',


### PR DESCRIPTION
For the latest POTW, I submitted a solution using MoonScript, a little-known scripting language based off of CoffeeScript that compiles to Lua. Of course, it's extension wasn't listed, so I added it.